### PR TITLE
Ordered dict for all actions

### DIFF
--- a/ocds_documentation_support/__init__.py
+++ b/ocds_documentation_support/__init__.py
@@ -47,7 +47,7 @@ def jsonschema_extract(fileobj, keywords, comment_tags, options):
                     yield value, '{}/{}'.format(pointer, key)
                 yield from gather_text(value, pointer='{}/{}'.format(pointer, key))
 
-    data = json.loads(fileobj.read().decode())
+    data = json.loads(fileobj.read().decode(), object_pairs_hook=OrderedDict)
     for text, pointer in gather_text(data):
         yield 1, '', text.strip(), [pointer]
 
@@ -157,7 +157,7 @@ def apply_extensions(basedir, profile_identifier, extension_versions):
         """
         Replaces `null` with sentinel values, to preserve the null'ing of fields by extensions in the final patch.
         """
-        return json.loads(re.sub(r':\s*null\b', ': "REPLACE_WITH_NULL"', content))
+        return json.loads(re.sub(r':\s*null\b', ': "REPLACE_WITH_NULL"', content), object_pairs_hook=OrderedDict)
 
     def pluck_fieldnames(fieldnames, basename):
         """


### PR DESCRIPTION
(From commit message by @timgdavies)

I noticed I was getting very complex diffs from apply-extension.py in the OCDS for PPPs repo, which I suspect may be due to not all areas of this file using ordered dicts, hence changes to ordering. 

This fix to test that.