### PR TITLE
Accept the OCDS version as an argument to translate_schema

### DIFF
--- a/ocdsdocumentationsupport/__init__.py
+++ b/ocdsdocumentationsupport/__init__.py
@@ -11,7 +11,7 @@ TRANSLATABLE_SCHEMA_KEYWORDS = ('title', 'description')
 VALID_FIELDNAMES = ('Code', 'Title', 'Description', 'Extension')
 
 
-def build_profile(basedir, standard_tag, standard_version, extension_versions, registry_base_url=None):
+def build_profile(basedir, standard_tag, extension_versions, registry_base_url=None):
     """
     Pulls extensions into a profile.
 
@@ -50,7 +50,7 @@ def build_profile(basedir, standard_tag, standard_version, extension_versions, r
             writer.writeheader()
             writer.writerows(codelist)
 
-    builder = ProfileBuilder(standard_tag, standard_version, extension_versions, registry_base_url)
+    builder = ProfileBuilder(standard_tag, extension_versions, registry_base_url)
     extension_codelists = builder.extension_codelists()
     directories_and_schema = {
         'profile': builder.release_schema_patch(),

--- a/ocdsdocumentationsupport/profile_builder.py
+++ b/ocdsdocumentationsupport/profile_builder.py
@@ -24,13 +24,12 @@ def _json_loads(data):
 
 
 class ProfileBuilder:
-    def __init__(self, standard_tag, standard_version, extension_versions, registry_base_url=None):
+    def __init__(self, standard_tag, extension_versions, registry_base_url=None):
         """
         Accepts an OCDS version and a dictionary of extension identifiers and versions, and initializes a reader of the
         extension registry.
         """
         self.standard_tag = standard_tag
-        self.standard_version = standard_version
         self.extension_versions = extension_versions
         self._file_cache = {}
 
@@ -64,7 +63,7 @@ class ProfileBuilder:
         """
         Returns the patched release schema.
         """
-        data = self.get_standard_file_contents('release-schema.json').replace('{{version}}', self.standard_version)
+        data = self.get_standard_file_contents('release-schema.json')
         return json_merge_patch.merge(_json_loads(data), self.release_schema_patch())
 
     def standard_codelists(self):

--- a/ocdsdocumentationsupport/translation.py
+++ b/ocdsdocumentationsupport/translation.py
@@ -51,7 +51,7 @@ def translate_codelists(domain, sourcedir, builddir, localedir, language):
                 writer.writerow(new_row)
 
 
-def translate_schema(domain, filenames, sourcedir, builddir, localedir, language):
+def translate_schema(domain, filenames, sourcedir, builddir, localedir, language, ocds_version):
     """
     Writes files, translating the "title" and "description" values of JSON Schema files.
 
@@ -65,14 +65,13 @@ def translate_schema(domain, filenames, sourcedir, builddir, localedir, language
     *  builddir: The path to the build directory.
     *  localedir: The path to the `locale` directory.
     *  language: A two-letter lowercase ISO369-1 code or BCP47 language tag.
+    *  ocds_version: The minor version of OCDS to substitute into URL patterns.
     """
     logger.info('Translating schema to {} using "{}" domain, from {} to {}'.format(
         language, domain, sourcedir, builddir))
 
     for name in filenames:
         os.makedirs(os.path.dirname(os.path.join(builddir, name)), exist_ok=True)
-
-    version = os.environ.get('TRAVIS_BRANCH', 'latest')
 
     # This should roughly match the logic of the `extract_schema` Babel extractor.
     def translate_data(data):
@@ -84,7 +83,7 @@ def translate_schema(domain, filenames, sourcedir, builddir, localedir, language
                 if isinstance(value, str):
                     value = value.strip()
                     if key in TRANSLATABLE_SCHEMA_KEYWORDS and value:
-                        data[key] = translator.gettext(value).replace('{{version}}', version).replace('{{lang}}', language)  # noqa: E501
+                        data[key] = translator.gettext(value).replace('{{version}}', ocds_version).replace('{{lang}}', language)  # noqa: E501
                 translate_data(value)
 
     translator = gettext.translation(domain, localedir, languages=[language], fallback=language == 'en')

--- a/tests/test_profile_builder.py
+++ b/tests/test_profile_builder.py
@@ -36,7 +36,7 @@ new_extension_codelists = [
 
 
 def test_extensions():
-    builder = ProfileBuilder('1__1__3', '1.1', OrderedDict([('charges', 'master'), ('location', 'v1.1.3')]))
+    builder = ProfileBuilder('1__1__3', OrderedDict([('charges', 'master'), ('location', 'v1.1.3')]))
     result = list(builder.extensions())
 
     assert len(result) == 2
@@ -58,7 +58,7 @@ def test_extensions():
 
 def test_release_schema_patch():
     # Use the ppp extension to test null values.
-    builder = ProfileBuilder('1__1__3', '1.1', OrderedDict([('ppp', 'v1.1.3'), ('location', 'v1.1.3')]))
+    builder = ProfileBuilder('1__1__3', OrderedDict([('ppp', 'master'), ('location', 'v1.1.3')]))
     result = builder.release_schema_patch()
 
     # Merges patches.
@@ -71,7 +71,7 @@ def test_release_schema_patch():
 
 def test_patched_release_schema():
     # Use the ppp extension to test null values.
-    builder = ProfileBuilder('1__1__3', '1.1', OrderedDict([('ppp', 'v1.1.3'), ('location', 'v1.1.3')]))
+    builder = ProfileBuilder('1__1__3', OrderedDict([('ppp', 'master'), ('location', 'v1.1.3')]))
     result = builder.patched_release_schema()
 
     # Patches core.
@@ -81,13 +81,9 @@ def test_patched_release_schema():
     # Removes null'ed fields.
     assert 'buyer' not in result['properties']
 
-    # Replaces {{version}}.
-    assert 'standard.open-contracting.org/{{version}}/' not in json.dumps(result)
-    assert 'standard.open-contracting.org/1.1/' in json.dumps(result)
-
 
 def test_standard_codelists():
-    builder = ProfileBuilder('1__1__3', '1.1', OrderedDict())
+    builder = ProfileBuilder('1__1__3', OrderedDict())
     result = builder.standard_codelists()
 
     # Collects codelists.
@@ -114,8 +110,8 @@ def test_extension_codelists(caplog):
         # charges and tariffs both have chargePaidBy.csv, but the content is identical, so should not error. ppp has
         # documentType.csv and tariffs has +documentType.csv, but documentType.csv contains the codes added by
         # +documentType.csv, so should not error. ppp and enquiries both have +partyRole.csv.
-        builder = ProfileBuilder('1__1__3', '1.1', OrderedDict([
-            ('ppp', 'v1.1.3'),
+        builder = ProfileBuilder('1__1__3', OrderedDict([
+            ('ppp', 'master'),
             ('enquiries', 'v1.1.3'),
             ('charges', 'master'),
             ('tariffs', 'master'),
@@ -128,10 +124,10 @@ def test_extension_codelists(caplog):
         assert [codelist.name for codelist in result] == [
             '+milestoneType.csv',
             '+partyRole.csv',
-            '-partyRole.csv',
             '+releaseTag.csv',
-            'initiationType.csv',
+            '-partyRole.csv',
             'documentType.csv',
+            'initiationType.csv',
         ] + new_extension_codelists
 
         # Preserves content.
@@ -155,8 +151,8 @@ def test_extension_codelists(caplog):
 
 def test_patched_codelists(caplog):
     with caplog.at_level(logging.INFO):
-        builder = ProfileBuilder('1__1__3', '1.1', OrderedDict([
-            ('ppp', 'v1.1.3'),
+        builder = ProfileBuilder('1__1__3', OrderedDict([
+            ('ppp', 'master'),
             ('charges', 'master'),
             ('tariffs', 'master'),
         ]))
@@ -193,7 +189,7 @@ def test_patched_codelists(caplog):
 
 
 def test_get_standard_file_contents():
-    builder = ProfileBuilder('1__1__3', '1.1', OrderedDict())
+    builder = ProfileBuilder('1__1__3', OrderedDict())
     data = builder.get_standard_file_contents('release-schema.json')
     # Repeat requests should return the same result.
     data = builder.get_standard_file_contents('release-schema.json')

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -7,12 +7,12 @@ from tempfile import TemporaryDirectory
 from ocdsdocumentationsupport.translation import translate_codelists, translate_schema
 
 codelist = """Code,Title,Description
-open,  Open  ,All interested suppliers may submit a tender.
-selective,  Selective  ,Only qualified suppliers are invited to submit a tender.
-"""
+open,  Open  ,  All interested suppliers may submit a tender.  
+selective,  Selective  ,  Only qualified suppliers are invited to submit a tender.  
+"""  # noqa
 
 schema = """{
-  "title": "Schema for an Open Contracting Record package",
+  "title": "Schema for an Open Contracting Record package {{version}}",
   "description": "The record package contains a list of records along with some publishing…",
   "definitions": {
     "record": {
@@ -23,11 +23,11 @@ schema = """{
           "oneOf": [
             {
               "title": "  Linked releases  ",
-              "description": "A list of objects that identify the releases associated with this Open…"
+              "description": "  A list of objects that identify the releases associated with this Open…  "
             },
             {
               "title": "  Embedded releases  ",
-              "description": "A list of releases, with all the data. The releases MUST be sorted into date…"
+              "description": "  A list of releases, with all the data. The releases MUST be sorted into date…  "
             }
           ]
         }
@@ -88,7 +88,7 @@ def test_translate_schema(monkeypatch, caplog):
 
         def gettext(self, *args, **kwargs):
             return {
-                'Schema for an Open Contracting Record package': 'Esquema para un paquete de Registros de Contrataciones Abiertas',  # noqa
+                'Schema for an Open Contracting Record package {{version}}': 'Esquema para un paquete de Registros de Contrataciones Abiertas {{version}}',  # noqa
                 'The record package contains a list of records along with some publishing…':  'El paquete de registros contiene una lista de registros junto con algunos…',  # noqa
                 'Releases': 'Entregas',
                 'An array of linking identifiers or releases': 'Una matriz de enlaces a identificadores o entregas',
@@ -108,7 +108,7 @@ def test_translate_schema(monkeypatch, caplog):
             f.write(schema)
 
         with TemporaryDirectory() as builddir:
-            translate_schema('schema', ['record-package-schema.json'], sourcedir, builddir, '', 'es')
+            translate_schema('schema', ['record-package-schema.json'], sourcedir, builddir, '', 'es', '1.1')
 
             with open(os.path.join(builddir, 'record-package-schema.json')) as f:
                 data = json.load(f)
@@ -116,7 +116,7 @@ def test_translate_schema(monkeypatch, caplog):
             assert not os.path.exists(os.path.join(builddir, 'untranslated.json'))
 
             assert data == {
-              "title": "Esquema para un paquete de Registros de Contrataciones Abiertas",
+              "title": "Esquema para un paquete de Registros de Contrataciones Abiertas 1.1",
               "description": "El paquete de registros contiene una lista de registros junto con algunos…",
               "definitions": {
                 "record": {


### PR DESCRIPTION
Instead of replacing it when patching the schema

Related https://github.com/open-contracting/public-private-partnerships/issues/170