### PR TITLE
Specify deploy schema path

### DIFF
--- a/ocdsdocumentationsupport/__init__.py
+++ b/ocdsdocumentationsupport/__init__.py
@@ -53,8 +53,11 @@ def build_profile(basedir, standard_tag, extension_versions, registry_base_url=N
     builder = ProfileBuilder(standard_tag, extension_versions, registry_base_url, schema_deploy_url)
     extension_codelists = builder.extension_codelists()
     directories_and_schema = {
-        'profile': builder.release_schema_patch(),
-        'patched': builder.patched_release_schema(),
+        'profile': {"release-schema.json": builder.release_schema_patch()},
+        'patched': {
+            "release-schema.json": builder.patched_release_schema(),
+            "release-package-schema.json": builder.release_package_schema()
+        }
     }
 
     # Write the documentation files.
@@ -63,8 +66,9 @@ def build_profile(basedir, standard_tag, extension_versions, registry_base_url=N
             f.write(extension.remote('README.md'))
 
     # Write the JSON Merge Patch and JSON Schema files.
-    for directory, schema in directories_and_schema.items():
-        write_json_file(schema, directory, 'release-schema.json')
+    for directory, schemas in directories_and_schema.items():
+        for filename, schema in schemas.items():
+            write_json_file(schema, directory, filename)
 
     # Write the extensions' codelists.
     for codelist in extension_codelists:

--- a/ocdsdocumentationsupport/__init__.py
+++ b/ocdsdocumentationsupport/__init__.py
@@ -11,7 +11,7 @@ TRANSLATABLE_SCHEMA_KEYWORDS = ('title', 'description')
 VALID_FIELDNAMES = ('Code', 'Title', 'Description', 'Extension')
 
 
-def build_profile(basedir, standard_tag, extension_versions, registry_base_url=None, schema_deploy_url=None):
+def build_profile(basedir, standard_tag, extension_versions, registry_base_url=None, schema_base_url=None):
     """
     Pulls extensions into a profile.
 
@@ -50,13 +50,15 @@ def build_profile(basedir, standard_tag, extension_versions, registry_base_url=N
             writer.writeheader()
             writer.writerows(codelist)
 
-    builder = ProfileBuilder(standard_tag, extension_versions, registry_base_url, schema_deploy_url)
+    builder = ProfileBuilder(standard_tag, extension_versions, registry_base_url, schema_base_url)
     extension_codelists = builder.extension_codelists()
-    directories_and_schema = {
-        'profile': {"release-schema.json": builder.release_schema_patch()},
+    directories_and_schemas = {
+        'profile': {
+            'release-schema.json': builder.release_schema_patch(),
+        },
         'patched': {
-            "release-schema.json": builder.patched_release_schema(),
-            "release-package-schema.json": builder.release_package_schema()
+            'release-schema.json': builder.patched_release_schema(),
+            'release-package-schema.json': builder.release_package_schema(),
         }
     }
 
@@ -66,7 +68,7 @@ def build_profile(basedir, standard_tag, extension_versions, registry_base_url=N
             f.write(extension.remote('README.md'))
 
     # Write the JSON Merge Patch and JSON Schema files.
-    for directory, schemas in directories_and_schema.items():
+    for directory, schemas in directories_and_schemas.items():
         for filename, schema in schemas.items():
             write_json_file(schema, directory, filename)
 

--- a/ocdsdocumentationsupport/__init__.py
+++ b/ocdsdocumentationsupport/__init__.py
@@ -11,7 +11,7 @@ TRANSLATABLE_SCHEMA_KEYWORDS = ('title', 'description')
 VALID_FIELDNAMES = ('Code', 'Title', 'Description', 'Extension')
 
 
-def build_profile(basedir, standard_tag, extension_versions, registry_base_url=None):
+def build_profile(basedir, standard_tag, extension_versions, registry_base_url=None, schema_deploy_url=None):
     """
     Pulls extensions into a profile.
 
@@ -50,7 +50,7 @@ def build_profile(basedir, standard_tag, extension_versions, registry_base_url=N
             writer.writeheader()
             writer.writerows(codelist)
 
-    builder = ProfileBuilder(standard_tag, extension_versions, registry_base_url)
+    builder = ProfileBuilder(standard_tag, extension_versions, registry_base_url, schema_deploy_url)
     extension_codelists = builder.extension_codelists()
     directories_and_schema = {
         'profile': builder.release_schema_patch(),

--- a/ocdsdocumentationsupport/profile_builder.py
+++ b/ocdsdocumentationsupport/profile_builder.py
@@ -74,6 +74,18 @@ class ProfileBuilder:
 
         return patched
 
+    def release_package_schema(self):
+        """
+        Returns the release package schema. Does not currently patch it.
+        """
+        data = _json_loads(self.get_standard_file_contents('release-package-schema.json'))
+
+        if self.schema_deploy_url:
+            data['id'] = urljoin(self.schema_deploy_url, 'release-package-schema.json')
+            data['properties']['releases']['items']['$ref'] = urljoin(self.schema_deploy_url, 'release-schema.json')
+
+        return data
+
     def standard_codelists(self):
         """
         Returns the standard's codelists as Codelist objects.

--- a/ocdsdocumentationsupport/profile_builder.py
+++ b/ocdsdocumentationsupport/profile_builder.py
@@ -25,7 +25,7 @@ def _json_loads(data):
 
 
 class ProfileBuilder:
-    def __init__(self, standard_tag, extension_versions, registry_base_url=None, schema_deploy_url=None):
+    def __init__(self, standard_tag, extension_versions, registry_base_url=None, schema_base_url=None):
         """
         Accepts an OCDS version and a dictionary of extension identifiers and versions, and initializes a reader of the
         extension registry.
@@ -33,9 +33,7 @@ class ProfileBuilder:
         self.standard_tag = standard_tag
         self.extension_versions = extension_versions
         self._file_cache = {}
-
-        # Allows specifiying where the released patched schema will be deployed, used to set 'id' field in the schema.
-        self.schema_deploy_url = schema_deploy_url
+        self.schema_base_url = schema_base_url
 
         # Allows setting the registry URL to e.g. a pull request, when working on a profile.
         if not registry_base_url:
@@ -67,22 +65,22 @@ class ProfileBuilder:
         """
         Returns the patched release schema.
         """
-        data = self.get_standard_file_contents('release-schema.json')
-        patched = json_merge_patch.merge(_json_loads(data), self.release_schema_patch())
-        if self.schema_deploy_url:
-            patched['id'] = urljoin(self.schema_deploy_url, 'release-schema.json')
+        content = self.get_standard_file_contents('release-schema.json')
+        patched = json_merge_patch.merge(_json_loads(content), self.release_schema_patch())
+        if self.schema_base_url:
+            patched['id'] = urljoin(self.schema_base_url, 'release-schema.json')
 
         return patched
 
     def release_package_schema(self):
         """
-        Returns the release package schema. Does not currently patch it.
+        Returns a release package schema. If `schema_base_url` was provided, updates schema URLs.
         """
         data = _json_loads(self.get_standard_file_contents('release-package-schema.json'))
 
-        if self.schema_deploy_url:
-            data['id'] = urljoin(self.schema_deploy_url, 'release-package-schema.json')
-            data['properties']['releases']['items']['$ref'] = urljoin(self.schema_deploy_url, 'release-schema.json')
+        if self.schema_base_url:
+            data['id'] = urljoin(self.schema_base_url, 'release-package-schema.json')
+            data['properties']['releases']['items']['$ref'] = urljoin(self.schema_base_url, 'release-schema.json')
 
         return data
 


### PR DESCRIPTION
Gives the options of specifying where deployed schema will live in order to get the id correct.

Also creates a `release-package-schema` as the `release-schema` will be hard to use without it.